### PR TITLE
Fixed crashes when passing in files.

### DIFF
--- a/antromo.py
+++ b/antromo.py
@@ -4,12 +4,17 @@
 
 from pynput import keyboard
 from sys import argv, stdout
+from os import path
 
 from consts import OPCODES
 from assemble import compileASM
 
 if not len(argv) == 2:
     print("usage: %s [file]" % (argv[0]))
+    exit(1)
+
+if not path.exists(argv[1]):
+    print("error: no such file or directory: '%s'" % (argv[1]))
     exit(1)
 
 f = open(argv[1], "rb")

--- a/antromo.py
+++ b/antromo.py
@@ -8,6 +8,10 @@ from sys import argv, stdout
 from consts import OPCODES
 from assemble import compileASM
 
+if not len(argv) == 2:
+    print("usage: %s [file]" % (argv[0]))
+    exit(1)
+
 f = open(argv[1], "rb")
 
 if argv[1].endswith(".atms"):

--- a/assemble.py
+++ b/assemble.py
@@ -4,6 +4,7 @@
 
 from sys import argv
 import shlex
+from os import path
 
 from consts import OPCODES
 
@@ -81,8 +82,11 @@ def compileASM(data):
 if __name__ == "__main__":
     if not len(argv) == 2:
         print("usage: %s [file]" % (argv[0]))
-        exit(0)
+        exit(1)
 
+    if not path.exists(argv[1]):
+        print("error: no such file or directory: '%s'" % (argv[1]))
+        exit(1)
 
     f = open(argv[1], "r")
 

--- a/assemble.py
+++ b/assemble.py
@@ -79,6 +79,11 @@ def compileASM(data):
     return output
 
 if __name__ == "__main__":
+    if not len(argv) == 2:
+        print("usage: %s [file]" % (argv[0]))
+        exit(0)
+
+
     f = open(argv[1], "r")
 
     data = f.read()


### PR DESCRIPTION
- Made it so the code doesn't just crash if you don't pass in an argument, now giving ``usage: (program being run) [file]`` and exits with a code of 1.
- Checks if the file being passed in exists, rather than trying to read the file and letting the code crash. Now gives back ``error: no such file or directory: '(file passed in)`` and exits with a code of 1.